### PR TITLE
Add bounty url to note reply and properly link reply

### DIFF
--- a/src/components/bounty/bountyLargeInfo/bountyLargeInfo.tsx
+++ b/src/components/bounty/bountyLargeInfo/bountyLargeInfo.tsx
@@ -176,7 +176,14 @@ function BountyLargeInfor({ ev }: event) {
             />
             <button
               onClick={() => {
-                addReward(rewardToAdd, rewardNoteToAdd, ev.pubkey, ev.Dtag);
+                addReward(
+                  rewardToAdd,
+                  rewardNoteToAdd,
+                  ev.pubkey,
+                  ev.Dtag,
+                  ev.id,
+                  naddr
+                );
                 setRewardToAdd("");
               }}
               className="rounded-lg px-4 py-2 text-sm text-white dark:text-white font-bold bg-blue-1 hover:bg-blue-800"

--- a/src/utils.tsx
+++ b/src/utils.tsx
@@ -134,8 +134,10 @@ export async function sendReply(
 export async function addReward(
   amount: string,
   note: string,
+  id: string,
   pubkey: string,
-  dTag: string
+  dTag: string,
+  naddr: string
 ) {
   let relays = defaultRelays;
 
@@ -143,10 +145,11 @@ export async function addReward(
     console.log("add a value");
   } else {
     let eventNote: string;
+    let rootBountyUrl = `https://nostrbounties.com/b/${naddr}`;
     if (note.length > 0) {
-      eventNote = `I just added ${amount} sats to this bounty! ${note}`;
+      eventNote = `I just added ${amount} sats to ${rootBountyUrl}! ${note}`;
     } else {
-      eventNote = `I just added ${amount} sats to this bounty!`;
+      eventNote = `I just added ${amount} sats to ${rootBountyUrl}!`;
     }
 
     let eventMessage = {
@@ -158,6 +161,7 @@ export async function addReward(
         ["t", "bounty-added-reward"],
         ["reward", `${amount}`],
         ["a", `30023:${pubkey}:${dTag}`],
+        ["e", `${id}`, "", "root"],
       ],
       content: eventNote,
       sig: null,


### PR DESCRIPTION
This adds a few small improvements: 

1. Adds the link to the bounty on nostrbounties.com in the body of the reply note. 
2. Properly links the reply note to the original `kind: 1` note that is published along with the bounty.